### PR TITLE
More unit tests

### DIFF
--- a/oidc_client/endpoints/callback.py
+++ b/oidc_client/endpoints/callback.py
@@ -18,7 +18,7 @@ async def callback_request(request):
 
     # Verify, that states match
     if not state == params['state']:
-        raise web.HTTPForbidden(text='401 Bad user session.')
+        raise web.HTTPForbidden(text='403 Bad user session.')
 
     # Request access token from AAI server
     access_token = await request_token(params['code'])

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,25 +1,73 @@
 import asynctest
 
+from unittest.mock import patch
+
 from aiohttp import web
 
 from oidc_client.endpoints.login import login_request
 from oidc_client.endpoints.logout import logout_request
-# from oidc_client.endpoints.callback import callback_request
+from oidc_client.endpoints.callback import callback_request
+
+from oidc_client.utils.utils import save_to_cookies
+
+
+class MockResponse:
+    """Mocked response class for testing cookies."""
+
+    def __init__(self):
+        """Initialise object."""
+        self.cookies = {}
+
+    def set_cookie(self, key, value, domain, max_age, secure, httponly):
+        """Set a cookie."""
+        self.cookies.update(
+            {
+                key: value,
+                'domain': domain,
+                'max_age': max_age,
+                'secure': secure,
+                'httponly': httponly
+            }
+        )
+
+
+class MockRequest:
+    """Mocked request class for testing."""
+
+    def __init__(self, cookies, query):
+        """Initialise object."""
+        self.cookies = cookies
+        self.query = query
 
 
 class TestEndpoints(asynctest.TestCase):
     """Test endpoint processors."""
 
-    # Tests to do for login processor:
-    # 1. Mock generate_state()
-    # 2. Mock web.HTTPSeeOther()
-    # 3. Mock save_to_cookies()
-    # 4. Test that 303 is raised with generated url
-    # 5. Test that response contains saved cookies
-    async def test_login_endpoint(self):
+    @patch('aiohttp.web.HTTPSeeOther')
+    @patch('oidc_client.endpoints.login.generate_state')
+    async def test_login_endpoint(self, m_state, m_response):
         """Test login endpoint processor."""
+        m_state.return_value = 5000
+        assert 5000 == m_state()
+        m_response.return_value = MockResponse()
+        # This test always passes
+        # url = 'https://aai.org/auth?client_id=public&response_type=code&state=5000&redirect_uri=localhost:5000&scope=openid%20ga4gh'
+        # assert m_response.called_with(url)
+        expected_cookies = {
+            'oidc_state': 5000,
+            'domain': 'localhost:8080',
+            'httponly': True,
+            'max_age': 3600,
+            'secure': True
+        }
+        m_response_with_cookies = await save_to_cookies(m_response(),
+                                                        key='oidc_state',
+                                                        value=m_state(),
+                                                        lifetime=3600,
+                                                        http_only=True)
+        assert m_response_with_cookies.cookies == expected_cookies
         with self.assertRaises(web.HTTPSeeOther):
-            await login_request({})
+            await login_request(web.Request)
 
     async def test_logout_endpoint(self):
         """Test logout endpoint processor."""
@@ -28,19 +76,41 @@ class TestEndpoints(asynctest.TestCase):
         with self.assertRaises(web.HTTPNotImplemented):
             await logout_request({})
 
-    # Tests to do for callback processor:
-    # 1. Mock state from get_from_cookies()
-    # 2. Mock params from query_params()
-    # 3. Test for good state and bad state (OK and 401)
-    # 4. Mock token from request_token()
-    # 5. Test that 303 is raised with url
-    # 6. Mock bona fide status from check_bona_fide()
-    # 7. Mock save_to_cookies()
-    # 8. Test that response contains saved cookies
-    # async def test_callback_endpoint(self):
-    #     """Test callback endpoint processor."""
-    #     with self.assertRaises(web.HTTPSeeOther):
-    #         await callback_request({})
+    @asynctest.mock.patch('oidc_client.endpoints.callback.check_bona_fide')
+    @asynctest.mock.patch('oidc_client.endpoints.callback.request_token')
+    async def test_callback_endpoint(self, m_token, m_bona):
+        """Test callback endpoint processor."""
+        # Test bad request: request doesn't pass state validation
+        bad_request = MockRequest(
+            cookies={'oidc_state': 5000},
+            query={'state': 9999, 'code': 'malicious bunnies'}
+        )
+        with self.assertRaises(web.HTTPForbidden):
+            await callback_request(bad_request)
+        # Test good request: request passes state validation and does a redirect
+        good_request = MockRequest(
+            cookies={'oidc_state': 5000},
+            query={'state': 5000, 'code': 'fluffy bunnies'}
+        )
+        m_token.return_value = 'super.secret.token'
+        m_bona.return_value = True
+        with self.assertRaises(web.HTTPSeeOther):
+            await callback_request(good_request)
+        # Test that access token is saved
+        mock_response = MockResponse()
+        expected_cookies = {
+            'access_token': 'super.secret.token',
+            'domain': 'localhost:8080',
+            'httponly': True,
+            'max_age': 3600,
+            'secure': True
+        }
+        m_response_with_cookies = await save_to_cookies(mock_response,
+                                                        key='access_token',
+                                                        value=await m_token(),
+                                                        lifetime=3600,
+                                                        http_only=True)
+        assert m_response_with_cookies.cookies == expected_cookies
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,10 @@
 import asynctest
 
 from collections import namedtuple
-# from ssl import SSLContext
-from unittest.mock import MagicMock  # , patch
+from unittest.mock import MagicMock, patch
 
 from aiohttp import web
 from aioresponses import aioresponses
-# from testfixtures import TempDirectory
 
 from multidict import MultiDict
 
@@ -40,29 +38,31 @@ class MockResponse:
         )
 
 
+class MockSSL:
+    """Mocked SSLContext."""
+
+    def __init__(self):
+        """Initialise object."""
+        self.cert = ''
+        self.key = ''
+
+    def load_cert_chain(self, cert, key):
+        """Read certificate and key files."""
+        self.cert = cert
+        self.key = key
+
+
 class TestUtils(asynctest.TestCase):
     """Test supporting utility functions."""
 
-    # @patch('os.path.isfile')
-    # @patch('ssl.SSLContext')
-    # def test_ssl_context(self, m_ssl, m_os):
-    def test_ssl_context(self):
+    @patch('os.path.isfile')
+    @patch('oidc_client.utils.utils.ssl.create_default_context')
+    def test_ssl_context(self, m_ssl, m_os):
         """Test ssl context."""
-        # Test for ssl context loaded
-        #
-        # with TempDirectory() as d:
-        #     d.makedir('testdir')
-        #     d.write('testdir/cert.pem', 'certfile'.encode('utf-8'))
-        #     d.write('testdir/key.pem', 'keyfile'.encode('utf-8'))
-        #     self.assertEqual(ssl_context('testdir/cert.pem', 'testdir/key.pem'), SSLContext)  # just to see what happens
-        #     self.assertTrue(isinstance(ssl_context('testdir/cert.pem', 'testdir/key.pem'), SSLContext))  # actual assert
-        #     d.cleanup()
-        #
-        # m_os.return_value = True
-        # m_ssl.load_cert_chain = {}  # ?
-        # self.assertEqual(ssl_context('cert.pem', 'key.pem'), SSLContext)  # just to see what happens
-        # self.assertTrue(isinstance(ssl_context('cert.pem', 'key.pem'), SSLContext))  # actual assert
-        #
+        # Test for files are found, and mock loading of files
+        m_os.return_value = True
+        m_ssl.return_value = MockSSL()
+
         # Test for ssl context not loaded, files are missing
         assert ssl_context('/missing/cert.pem', '/missing/key.pem') is None
 


### PR DESCRIPTION
### Description
Not sure about unit test for `ssl_context()`. I mocked the `ssl.SSLContext.load_cert_chain()` with a mock object, but it only helps with bypassing the file loading.

I also tried to test with `TempDirectory`
- With bogus file contents it resulted in `OSError: [Errno 22] Invalid argument`
- With real `.pem` file contents it resulted in `ssl.SSLError: [SSL] PEM lib (_ssl.c:3401)`

### Related issues
Fixes #5 

### Testing

- [x] Unit Tests