### PR TITLE
validate token before continuing

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -11,7 +11,7 @@ Default values can be seen in the configuration file parser, they are the right-
 
 .. literalinclude:: /../oidc_client/config/__init__.py
    :language: python
-   :lines: 15-41
+   :lines: 15-45
 
 The default values can be overwritten and saved to file in the ``config.ini`` configuration file.
 The configuration file has three basic sections: ``app`` for application configuration, ``cookie`` for cookie
@@ -43,7 +43,7 @@ AAI Server Configuration
 
 .. literalinclude:: /../oidc_client/config/config.ini
    :language: python
-   :lines: 56-82
+   :lines: 56-94
 
 .. _elixir-conf:
 
@@ -52,7 +52,7 @@ ELIXIR Configuration
 
 .. literalinclude:: /../oidc_client/config/config.ini
    :language: python
-   :lines: 84-89
+   :lines: 96-101
 
 .. _env:
 

--- a/oidc_client/config/__init__.py
+++ b/oidc_client/config/__init__.py
@@ -34,7 +34,11 @@ def parse_config_file(path):
             'url_userinfo': os.environ.get('URL_USERINFO', config.get('aai', 'url_userinfo')) or None,
             'url_callback': os.environ.get('URL_CALLBACK', config.get('aai', 'url_callback')) or None,
             'url_redirect': os.environ.get('URL_REDIRECT', config.get('aai', 'url_redirect')) or None,
-            'scope': os.environ.get('SCOPE', config.get('aai', 'scope')) or 'openid'
+            'scope': os.environ.get('SCOPE', config.get('aai', 'scope')) or 'openid',
+            'iss': os.environ.get('ISS', config.get('aai', 'iss')) or None,
+            'aud': os.environ.get('AUD', config.get('aai', 'aud')) or None,
+            'jwk': os.environ.get('JWK', config.get('aai', 'jwk')) or None,
+            'jwk_server': os.environ.get('JWK_SERVER', config.get('aai', 'jwk_server')) or None
         },
         'elixir': {
             'bona_fide_value': os.environ.get('BONA_FIDE_VALUE', config.get('elixir', 'bona_fide_value')) or ''

--- a/oidc_client/config/config.ini
+++ b/oidc_client/config/config.ini
@@ -64,13 +64,13 @@ client_id=public
 client_secret=secret
 
 # URL where authentication workflow begins
-url_auth=https://aai.org/auth
+url_auth=https://login.elixir-czech.org/oidc/authorize
 
 # URL that returns access token
-url_token=https://aai.org/token
+url_token=https://login.elixir-czech.org/oidc/token
 
 # URL for the userinfo endpoint at AAI
-url_userinfo=https://aai.org/userinfo
+url_userinfo=https://login.elixir-czech.org/oidc/userinfo
 
 # URL the AAI should return to after authentication
 url_callback=localhost:8080/callback
@@ -80,6 +80,18 @@ url_redirect=localhost:5000
 
 # Claims requested for access token, for multiple values separate scopes by commas ','
 scope=openid,ga4gh
+
+# Trusted issuers of access token, separate multiple issuers with commas ','
+iss=https://login.elixir-czech.org/oidc/
+
+# Intended audiences of access token, separate multiple audiences with commas ','
+aud=audience1,audience2
+
+# JWK used to decode the JWT access token
+jwk=
+
+# Server that returns JWK
+jwk_server=https://login.elixir-czech.org/oidc/jwk
 
 # ****************************
 # Configuration for ELIXIR AAI

--- a/oidc_client/endpoints/callback.py
+++ b/oidc_client/endpoints/callback.py
@@ -2,7 +2,7 @@
 
 from aiohttp import web
 
-from ..utils.utils import get_from_cookies, save_to_cookies, request_token, query_params, check_bona_fide
+from ..utils.utils import get_from_cookies, save_to_cookies, request_token, query_params, check_bona_fide, validate_token
 from ..config import CONFIG
 from ..utils.logging import LOG
 
@@ -22,6 +22,9 @@ async def callback_request(request):
 
     # Request access token from AAI server
     access_token = await request_token(params['code'])
+
+    # Validate access token
+    await validate_token(access_token)
 
     # Prepare response
     response = web.HTTPSeeOther(CONFIG.aai['url_redirect'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 aiohttp
 gunicorn
 uvloop
+authlib
+aiocache

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='oidc_client',
 
           'Programming Language :: Python :: 3.6',
       ],
-      install_requires=['aiohttp', 'gunicorn', 'uvloop'],
+      install_requires=['aiohttp', 'gunicorn', 'uvloop', 'authlib', 'aiocache'],
       extras_require={
           'test': ['coverage', 'pytest', 'pytest-cov',
                    'coveralls', 'testfixtures', 'tox',

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -76,9 +76,10 @@ class TestEndpoints(asynctest.TestCase):
         with self.assertRaises(web.HTTPNotImplemented):
             await logout_request({})
 
+    @asynctest.mock.patch('oidc_client.endpoints.callback.validate_token')
     @asynctest.mock.patch('oidc_client.endpoints.callback.check_bona_fide')
     @asynctest.mock.patch('oidc_client.endpoints.callback.request_token')
-    async def test_callback_endpoint(self, m_token, m_bona):
+    async def test_callback_endpoint(self, m_token, m_bona, m_valid):
         """Test callback endpoint processor."""
         # Test bad request: request doesn't pass state validation
         bad_request = MockRequest(
@@ -92,6 +93,7 @@ class TestEndpoints(asynctest.TestCase):
             cookies={'oidc_state': 5000},
             query={'state': 5000, 'code': 'fluffy bunnies'}
         )
+        m_valid.return_value = True
         m_token.return_value = 'super.secret.token'
         m_bona.return_value = True
         with self.assertRaises(web.HTTPSeeOther):


### PR DESCRIPTION
### Description
Validate received token from AAI before continuing.

### Related issues
Fixes #9 

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Changes Made
New functions in `utils.py`
- `get_jwk()` to read JWK from configuration or request from server
- `validate_token()` to validate that token contains required claims and checks values for some of those claims
- New configuration variables `iss`, `aud`, `jwk`, `jwk_server`

### Testing
- [x] Unit Tests

### Mentions
Based on `beacon-python` token validation https://github.com/CSCfi/beacon-python/blob/master/beacon_api/utils/validate.py#L127