### PR TITLE
Implement a logout endpoint

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,9 +19,8 @@ Upon a successful authentication at the AAI, the user is returned to the ``/call
 Logout
 ~~~~~~
 
-The logout endpoint ``/logout`` is used to destroy sessions cookies and invalidate the access token.
-
-.. note:: ELIXIR AAI has not implemented a logout feature yet, so this feature is also missing from OIDC Client.
+The logout endpoint ``/logout`` is used to destroy the access token cookie and to revoke the access token at the AAI.
+Upon a successful logout procedure, the user is returned to the ``url_redirect`` address from the configuration file.
 
 Callback
 ~~~~~~~~

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -43,7 +43,7 @@ AAI Server Configuration
 
 .. literalinclude:: /../oidc_client/config/config.ini
    :language: python
-   :lines: 56-94
+   :lines: 56-97
 
 .. _elixir-conf:
 
@@ -52,7 +52,7 @@ ELIXIR Configuration
 
 .. literalinclude:: /../oidc_client/config/config.ini
    :language: python
-   :lines: 96-101
+   :lines: 99-104
 
 .. _env:
 

--- a/oidc_client/config/__init__.py
+++ b/oidc_client/config/__init__.py
@@ -34,6 +34,7 @@ def parse_config_file(path):
             'url_userinfo': os.environ.get('URL_USERINFO', config.get('aai', 'url_userinfo')) or None,
             'url_callback': os.environ.get('URL_CALLBACK', config.get('aai', 'url_callback')) or None,
             'url_redirect': os.environ.get('URL_REDIRECT', config.get('aai', 'url_redirect')) or None,
+            'url_revoke': os.environ.get('URL_REVOKE', config.get('aai', 'url_revoke')) or None,
             'scope': os.environ.get('SCOPE', config.get('aai', 'scope')) or 'openid',
             'iss': os.environ.get('ISS', config.get('aai', 'iss')) or None,
             'aud': os.environ.get('AUD', config.get('aai', 'aud')) or None,

--- a/oidc_client/config/config.ini
+++ b/oidc_client/config/config.ini
@@ -78,6 +78,9 @@ url_callback=localhost:8080/callback
 # URL the OIDC Client should redirect to after authentication
 url_redirect=localhost:5000
 
+# URL to the token revocation endpoint at AAI
+url_revoke=https://login.elixir-czech.org/oidc/revoke
+
 # Claims requested for access token, for multiple values separate scopes by commas ','
 scope=openid,ga4gh
 

--- a/oidc_client/config/config.ini
+++ b/oidc_client/config/config.ini
@@ -82,7 +82,7 @@ url_redirect=localhost:5000
 url_revoke=https://login.elixir-czech.org/oidc/revoke
 
 # Claims requested for access token, for multiple values separate scopes by commas ','
-scope=openid,ga4gh
+scope=openid,ga4gh_passport_v1
 
 # Trusted issuers of access token, separate multiple issuers with commas ','
 iss=https://login.elixir-czech.org/oidc/

--- a/oidc_client/endpoints/logout.py
+++ b/oidc_client/endpoints/logout.py
@@ -2,6 +2,8 @@
 
 from aiohttp import web
 
+from ..utils.utils import get_from_cookies, revoke_token, save_to_cookies
+from ..config import CONFIG
 from ..utils.logging import LOG
 
 
@@ -9,4 +11,21 @@ async def logout_request(request):
     """Handle logout requests."""
     LOG.debug('Handle logout request.')
 
-    raise web.HTTPNotImplemented()
+    # Read access token from cookies
+    access_token = get_from_cookies(request, 'access_token')
+
+    # Revoke token at AAI
+    revoke_token(access_token)
+
+    # Prepare response
+    response = web.HTTPSeeOther(CONFIG.aai['url_redirect'])
+
+    # Overwrite token cookie with an instantly expiring one
+    response = await save_to_cookies(response,
+                                     key='access_token',
+                                     value='token_has_been_revoked',
+                                     lifetime=0,
+                                     http_only=CONFIG.cookie['http_only'])
+
+    # Redirect user to UI, this does a 303 redirect
+    raise response

--- a/oidc_client/utils/utils.py
+++ b/oidc_client/utils/utils.py
@@ -24,7 +24,7 @@ def ssl_context(cert, key):
     context = None
     if os.path.isfile(cert) and os.path.isfile(key):
         LOG.debug('Found SSL cert and key, serve app as HTTPS.')
-        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        context = ssl.create_default_context()
         context.load_cert_chain(cert, key)
 
     # Debug log for start-up

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -69,11 +69,14 @@ class TestEndpoints(asynctest.TestCase):
         with self.assertRaises(web.HTTPSeeOther):
             await login_request(web.Request)
 
-    async def test_logout_endpoint(self):
+    @asynctest.mock.patch('oidc_client.endpoints.logout.revoke_token')
+    @asynctest.mock.patch('oidc_client.endpoints.logout.get_from_cookies')
+    async def test_logout_endpoint(self, m_cookies, m_rtoken):
         """Test logout endpoint processor."""
-        # logout endpoint is not yet implemented,
-        # added scaffolding here for future test
-        with self.assertRaises(web.HTTPNotImplemented):
+        m_cookies.return_value = 'token'
+        m_rtoken.return_value = True
+        # Test that logout redirects user
+        with self.assertRaises(web.HTTPSeeOther):
             await logout_request({})
 
     @asynctest.mock.patch('oidc_client.endpoints.callback.validate_token')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ from multidict import MultiDict
 
 from oidc_client.utils.utils import ssl_context, generate_state, get_from_cookies, save_to_cookies
 from oidc_client.utils.utils import request_token, query_params, check_bona_fide, get_jwk, validate_token
+from oidc_client.utils.utils import revoke_token
 
 # Mock URLs in functions to replace the real request, checks for http/https/localhost in the beginning
 MOCK_URL = re.compile(r'^(http|localhost)')
@@ -257,6 +258,17 @@ class TestUtils(asynctest.TestCase):
         m_jwk.return_value = 'another key'
         with self.assertRaises(web.HTTPForbidden):
             await validate_token(token)
+
+    @aioresponses()
+    async def test_revoke_token(self, m):
+        """Test token revocation."""
+        # Test successful revocation of token
+        m.get(MOCK_URL, status=200)
+        await revoke_token('token')
+        # Test failed revocation of token
+        m.get(MOCK_URL, status=400)
+        with self.assertRaises(web.HTTPBadRequest):
+            await revoke_token('what')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description
`/logout` endpoint can now be used to revoke the access token at AAI's side and to overwrite the `access_token` cookie.

### Related issues
https://github.com/CSCfi/beacon-network-ui/issues/11

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Changes Made
* `/logout` endpoint implemented;
* New variable in `config.ini` for `url_revoke` that points to a token revocation endpoint at AAI;
* New `utils/utils.py` function to revoke token at AAI;
* Updated docs on logout procedure.

### Testing
- [x] Unit Tests

### Mentions
Need to update UI code next to contact this endpoint.
https://github.com/CSCfi/beacon-network-ui/pull/20