### PR TITLE
Feature/persistent session key

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -11,7 +11,7 @@ Default values can be seen in the configuration file parser, they are the right-
 
 .. literalinclude:: /../oidc_client/config/__init__.py
    :language: python
-   :lines: 15-42
+   :lines: 17-50
 
 The default values can be overwritten and saved to file in the ``config.ini`` configuration file.
 The configuration file has three basic sections: ``app`` for application configuration, ``cookie`` for cookie
@@ -25,7 +25,7 @@ Application Configuration
 
 .. literalinclude:: /../oidc_client/config/config.ini
    :language: python
-   :lines: 18-29
+   :lines: 17-33
 
 .. _cookie-conf:
 
@@ -34,7 +34,7 @@ Cookie Settings
 
 .. literalinclude:: /../oidc_client/config/config.ini
    :language: python
-   :lines: 31-48
+   :lines: 35-52
 
 .. _aai-conf:
 
@@ -43,7 +43,7 @@ AAI Server Configuration
 
 .. literalinclude:: /../oidc_client/config/config.ini
    :language: python
-   :lines: 50-88
+   :lines: 54-92
 
 .. _env:
 

--- a/oidc_client/__init__.py
+++ b/oidc_client/__init__.py
@@ -1,7 +1,7 @@
 """OIDC Client."""
 
 __title__ = "oidc_client"
-__version__ = VERSION = "1.1.0"
+__version__ = VERSION = "1.2.0"
 __author__ = "CSC developers"
 __license__ = "Apache License 2.0"
 __copyright__ = "CSC - IT Center for Science"

--- a/oidc_client/app.py
+++ b/oidc_client/app.py
@@ -2,7 +2,6 @@
 
 import sys
 
-from cryptography.fernet import Fernet
 from aiohttp import web
 from aiohttp_session import setup as session_setup
 from aiohttp_session.cookie_storage import EncryptedCookieStorage
@@ -59,8 +58,8 @@ async def init() -> web.Application:
     server = web.Application()
 
     # Create encrypted session storage
-    # Encryption key must be a 32 byte base64-encoded Fernet key
-    session_setup(server, EncryptedCookieStorage(Fernet.generate_key()[:32]))
+    # Encryption key must be 32 len bytes
+    session_setup(server, EncryptedCookieStorage(CONFIG.app["session_key"].encode()))
 
     # Gather endpoints
     server.router.add_routes(routes)

--- a/oidc_client/config/__init__.py
+++ b/oidc_client/config/__init__.py
@@ -1,6 +1,7 @@
 """OIDC Client Configuration."""
 
 import os
+import secrets
 import logging
 
 from pathlib import Path
@@ -22,6 +23,7 @@ def parse_config_file(path):
             "host": os.environ.get("HOST", config.get("app", "host")) or "0.0.0.0",  # nosec
             "port": os.environ.get("PORT", config.get("app", "port")) or 8080,
             "name": os.environ.get("NAME", config.get("app", "name")) or "oidc-client",
+            "session_key": os.environ.get("SESSION_KEY", config.get("app", "session_key")) or secrets.token_hex(16),
         },
         "cookie": {
             "domain": os.environ.get("DOMAIN", config.get("cookie", "domain")) or "localhost",

--- a/oidc_client/config/config.ini
+++ b/oidc_client/config/config.ini
@@ -12,7 +12,6 @@
 # [aai] section contains configuration variables for the client-server communication with AAI
 # [cookie] section contains configuration variables for cookie management
 # Custom sections can be added in a similar fashion, and be loaded with config/__init__.py
-# An example custom section [elixir] has been added for ELIXIR AAI use case
 # -------------------------------------------------------------------------------------------------------
 
 # ****************************************
@@ -27,6 +26,11 @@ port=8080
 
 # Name for this API shown at root endpoint `/`
 name=oidc-client
+
+# Secret key to encrypt session storage, must be exactly 32 characters
+# If left empty, a session key will be generated with secrets.token_hex(16)
+# Share this key with other services, which need to decrypt the AIOHTTP_SESSION cookie
+session_key=
 
 # ***********************************
 # Configuration for cookie management


### PR DESCRIPTION
Implemented persistent session key for encrypted session storage to make integration possible to other services which want to use the encrypted `AIOHTTP_SESSION` cookie.

New:
- `[app]` `session_key` in `config.ini`
- Auto-generated with `secrets.token_hex(16)` if left empty