### PR TITLE
Fix/oidc spec

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -11,7 +11,7 @@ Default values can be seen in the configuration file parser, they are the right-
 
 .. literalinclude:: /../oidc_client/config/__init__.py
    :language: python
-   :lines: 17-50
+   :lines: 17-49
 
 The default values can be overwritten and saved to file in the ``config.ini`` configuration file.
 The configuration file has three basic sections: ``app`` for application configuration, ``cookie`` for cookie
@@ -43,7 +43,7 @@ AAI Server Configuration
 
 .. literalinclude:: /../oidc_client/config/config.ini
    :language: python
-   :lines: 54-92
+   :lines: 54-89
 
 .. _env:
 

--- a/oidc_client/__init__.py
+++ b/oidc_client/__init__.py
@@ -1,7 +1,7 @@
 """OIDC Client."""
 
 __title__ = "oidc_client"
-__version__ = VERSION = "1.2.0"
+__version__ = VERSION = "1.2.1"
 __author__ = "CSC developers"
 __license__ = "Apache License 2.0"
 __copyright__ = "CSC - IT Center for Science"

--- a/oidc_client/config/__init__.py
+++ b/oidc_client/config/__init__.py
@@ -37,7 +37,6 @@ def parse_config_file(path):
             "client_secret": os.environ.get("CLIENT_SECRET", config.get("aai", "client_secret")) or "secret",
             "url_auth": os.environ.get("URL_AUTH", config.get("aai", "url_auth")) or None,
             "url_token": os.environ.get("URL_TOKEN", config.get("aai", "url_token")) or None,
-            "url_userinfo": os.environ.get("URL_USERINFO", config.get("aai", "url_userinfo")) or None,
             "url_callback": os.environ.get("URL_CALLBACK", config.get("aai", "url_callback")) or None,
             "url_redirect": os.environ.get("URL_REDIRECT", config.get("aai", "url_redirect")) or None,
             "url_revoke": os.environ.get("URL_REVOKE", config.get("aai", "url_revoke")) or None,

--- a/oidc_client/config/config.ini
+++ b/oidc_client/config/config.ini
@@ -67,9 +67,6 @@ url_auth=https://login.elixir-czech.org/oidc/authorize
 # URL that returns access token
 url_token=https://login.elixir-czech.org/oidc/token
 
-# URL for the userinfo endpoint at AAI
-url_userinfo=https://login.elixir-czech.org/oidc/userinfo
-
 # URL the AAI should return to after authentication
 url_callback=localhost:8080/callback
 

--- a/oidc_client/endpoints/callback.py
+++ b/oidc_client/endpoints/callback.py
@@ -4,7 +4,7 @@ import secrets
 
 from aiohttp import web
 
-from ..utils.utils import get_from_session, save_to_session, save_to_cookies, request_tokens, query_params, validate_token, revoke_token
+from ..utils.utils import get_from_session, save_to_session, save_to_cookies, request_tokens, query_params, validate_token
 from ..config import CONFIG, LOG
 
 
@@ -28,10 +28,6 @@ async def callback_request(request: web.Request) -> web.HTTPSeeOther:
     # Validate tokens
     await validate_token(tokens["access_token"])
     await validate_token(tokens["id_token"])  # validated but not saved or used
-    if CONFIG.aai["url_revoke"]:
-        # Some OIDC OPs don't provide a logout endpoint, so we first check if it's configured before trying to revoke the token
-        # We want to revoke the id_token because we don't use it for anything, and we don't want to leave user data hanging
-        await revoke_token(tokens["id_token"])
 
     # Save access token to session storage
     await save_to_session(request, key="access_token", value=tokens["access_token"])

--- a/oidc_client/endpoints/callback.py
+++ b/oidc_client/endpoints/callback.py
@@ -4,7 +4,7 @@ import secrets
 
 from aiohttp import web
 
-from ..utils.utils import get_from_session, save_to_session, save_to_cookies, request_tokens, query_params, validate_token
+from ..utils.utils import get_from_session, save_to_session, save_to_cookies, request_tokens, query_params, validate_token, revoke_token
 from ..config import CONFIG, LOG
 
 
@@ -28,6 +28,10 @@ async def callback_request(request: web.Request) -> web.HTTPSeeOther:
     # Validate tokens
     await validate_token(tokens["access_token"])
     await validate_token(tokens["id_token"])  # validated but not saved or used
+    if CONFIG.aai["url_revoke"]:
+        # Some OIDC OPs don't provide a logout endpoint, so we first check if it's configured before trying to revoke the token
+        # We want to revoke the id_token because we don't use it for anything, and we don't want to leave user data hanging
+        await revoke_token(tokens["id_token"])
 
     # Save access token to session storage
     await save_to_session(request, key="access_token", value=tokens["access_token"])

--- a/oidc_client/endpoints/callback.py
+++ b/oidc_client/endpoints/callback.py
@@ -4,7 +4,7 @@ import secrets
 
 from aiohttp import web
 
-from ..utils.utils import get_from_session, save_to_session, save_to_cookies, request_token, query_params, validate_token
+from ..utils.utils import get_from_session, save_to_session, save_to_cookies, request_tokens, query_params, validate_token
 from ..config import CONFIG, LOG
 
 
@@ -22,21 +22,22 @@ async def callback_request(request: web.Request) -> web.HTTPSeeOther:
     if not secrets.compare_digest(str(state), str(params["state"])):
         raise web.HTTPForbidden(text="403 Bad user session.")
 
-    # Request access token from AAI server
-    access_token = await request_token(params["code"])
+    # Request id token and access token from AAI server
+    tokens = await request_tokens(params["code"])
 
-    # Validate access token
-    await validate_token(access_token)
+    # Validate tokens
+    await validate_token(tokens["access_token"])
+    await validate_token(tokens["id_token"])  # validated but not saved or used
 
     # Save access token to session storage
-    await save_to_session(request, key="access_token", value=access_token)
+    await save_to_session(request, key="access_token", value=tokens["access_token"])
 
     # Prepare response
     response = web.HTTPSeeOther(CONFIG.aai["url_redirect"])
 
     # Save the received access token to cookies for later use
     response = await save_to_cookies(
-        response, key="access_token", value=access_token, lifetime=CONFIG.cookie["token_lifetime"], http_only=CONFIG.cookie["http_only"]
+        response, key="access_token", value=tokens["access_token"], lifetime=CONFIG.cookie["token_lifetime"], http_only=CONFIG.cookie["http_only"]
     )
 
     # Save a logged-in cookie for UI purposes

--- a/oidc_client/utils/utils.py
+++ b/oidc_client/utils/utils.py
@@ -69,7 +69,7 @@ async def save_to_cookies(response: web.HTTPSeeOther, key: str = "key", value: s
     return response
 
 
-async def request_tokens(code: str) -> str:
+async def request_tokens(code: str) -> dict:
     """Request tokens from AAI."""
     LOG.debug("Requesting tokens.")
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -66,12 +66,14 @@ class TestEndpoints(asynctest.TestCase):
         with self.assertRaises(web.HTTPSeeOther):
             await logout_request({})
 
+    @asynctest.mock.patch("oidc_client.endpoints.callback.revoke_token")
     @asynctest.mock.patch("oidc_client.endpoints.callback.save_to_session")
     @asynctest.mock.patch("oidc_client.endpoints.callback.get_from_session")
     @asynctest.mock.patch("oidc_client.endpoints.callback.validate_token")
     @asynctest.mock.patch("oidc_client.endpoints.callback.request_tokens")
-    async def test_callback_endpoint(self, m_token, m_valid, m_session, m_save):
+    async def test_callback_endpoint(self, m_token, m_valid, m_session, m_save, m_revoke):
         """Test callback endpoint processor."""
+        m_revoke.return_value = True
         # Test bad request: request doesn't pass state validation
         m_session.return_value = 5000
         bad_request = MockRequest(query={"state": 9999, "code": "malicious bunnies"})

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -66,14 +66,12 @@ class TestEndpoints(asynctest.TestCase):
         with self.assertRaises(web.HTTPSeeOther):
             await logout_request({})
 
-    @asynctest.mock.patch("oidc_client.endpoints.callback.revoke_token")
     @asynctest.mock.patch("oidc_client.endpoints.callback.save_to_session")
     @asynctest.mock.patch("oidc_client.endpoints.callback.get_from_session")
     @asynctest.mock.patch("oidc_client.endpoints.callback.validate_token")
     @asynctest.mock.patch("oidc_client.endpoints.callback.request_tokens")
-    async def test_callback_endpoint(self, m_token, m_valid, m_session, m_save, m_revoke):
+    async def test_callback_endpoint(self, m_token, m_valid, m_session, m_save):
         """Test callback endpoint processor."""
-        m_revoke.return_value = True
         # Test bad request: request doesn't pass state validation
         m_session.return_value = 5000
         bad_request = MockRequest(query={"state": 9999, "code": "malicious bunnies"})


### PR DESCRIPTION
`id_token` was not handled
* removed deprecated configuration values
* validate `id_token` from AAI
* revoke `id_token` so it doesn't hang around, because it's not used