### PR TITLE
Feature/remove sessions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,8 +45,6 @@ Cookies created and used by the OIDC Client and their default settings.
 +-----------------+-----------+---------------------------------------------------------------------------------------------------------------------+----------+--------+-----------+
 | Cookie          | Origin    | Purpose                                                                                                             | Lifetime | Secure | Http Only |
 +-----------------+-----------+---------------------------------------------------------------------------------------------------------------------+----------+--------+-----------+
-| AIOHTTP_SESSION | /login    | Store state at login to be checked upon callback. Store access token at callback to be displayed at token endpoint. | Session  | True   | True      |
-+-----------------+-----------+---------------------------------------------------------------------------------------------------------------------+----------+--------+-----------+
 | access_token    | /callback | Sent along same-domain requests for authorizing access to data                                                      | 1 hour   | True   | True      |
 +-----------------+-----------+---------------------------------------------------------------------------------------------------------------------+----------+--------+-----------+
 | logged_in       | /callback | Used to display logged in state in UI                                                                               | 1 hour   | True   | False     |

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -25,7 +25,7 @@ Application Configuration
 
 .. literalinclude:: /../oidc_client/config/config.ini
    :language: python
-   :lines: 17-33
+   :lines: 17-28
 
 .. _cookie-conf:
 
@@ -34,7 +34,7 @@ Cookie Settings
 
 .. literalinclude:: /../oidc_client/config/config.ini
    :language: python
-   :lines: 35-52
+   :lines: 30-47
 
 .. _aai-conf:
 
@@ -43,7 +43,7 @@ AAI Server Configuration
 
 .. literalinclude:: /../oidc_client/config/config.ini
    :language: python
-   :lines: 54-92
+   :lines: 49-90
 
 .. _env:
 

--- a/oidc_client/__init__.py
+++ b/oidc_client/__init__.py
@@ -1,7 +1,7 @@
 """OIDC Client."""
 
 __title__ = "oidc_client"
-__version__ = VERSION = "1.2.1"
+__version__ = VERSION = "1.3.0"
 __author__ = "CSC developers"
 __license__ = "Apache License 2.0"
 __copyright__ = "CSC - IT Center for Science"

--- a/oidc_client/app.py
+++ b/oidc_client/app.py
@@ -3,8 +3,6 @@
 import sys
 
 from aiohttp import web
-from aiohttp_session import setup as session_setup
-from aiohttp_session.cookie_storage import EncryptedCookieStorage
 
 from .endpoints.login import login_request
 from .endpoints.logout import logout_request
@@ -56,10 +54,6 @@ async def init() -> web.Application:
 
     # Initialise server object
     server = web.Application()
-
-    # Create encrypted session storage
-    # Encryption key must be 32 len bytes
-    session_setup(server, EncryptedCookieStorage(CONFIG.app["session_key"].encode()))
 
     # Gather endpoints
     server.router.add_routes(routes)

--- a/oidc_client/config/__init__.py
+++ b/oidc_client/config/__init__.py
@@ -1,7 +1,6 @@
 """OIDC Client Configuration."""
 
 import os
-import secrets
 import logging
 
 from pathlib import Path
@@ -23,7 +22,6 @@ def parse_config_file(path):
             "host": os.environ.get("HOST", config.get("app", "host")) or "0.0.0.0",  # nosec
             "port": os.environ.get("PORT", config.get("app", "port")) or 8080,
             "name": os.environ.get("NAME", config.get("app", "name")) or "oidc-client",
-            "session_key": os.environ.get("SESSION_KEY", config.get("app", "session_key")) or secrets.token_hex(16),
         },
         "cookie": {
             "domain": os.environ.get("DOMAIN", config.get("cookie", "domain")) or "localhost",
@@ -45,6 +43,7 @@ def parse_config_file(path):
             "iss": os.environ.get("ISS", config.get("aai", "iss")) or None,
             "aud": os.environ.get("AUD", config.get("aai", "aud")) or None,
             "jwk_server": os.environ.get("JWK_SERVER", config.get("aai", "jwk_server")) or None,
+            "token_type": os.environ.get("TOKEN_TYPE", config.get("aai", "token_type")) or None,
         },
     }
     return namedtuple("Config", config_vars.keys())(*config_vars.values())

--- a/oidc_client/config/config.ini
+++ b/oidc_client/config/config.ini
@@ -27,11 +27,6 @@ port=8080
 # Name for this API shown at root endpoint `/`
 name=oidc-client
 
-# Secret key to encrypt session storage, must be exactly 32 characters
-# If left empty, a session key will be generated with secrets.token_hex(16)
-# Share this key with other services, which need to decrypt the AIOHTTP_SESSION cookie
-session_key=
-
 # ***********************************
 # Configuration for cookie management
 # ***********************************
@@ -90,3 +85,6 @@ aud=audience1,audience2
 
 # Server that returns JWK
 jwk_server=https://login.elixir-czech.org/oidc/jwk
+
+# Token type, if token_type=opaque, the token will not be validated
+token_type=

--- a/oidc_client/endpoints/login.py
+++ b/oidc_client/endpoints/login.py
@@ -4,7 +4,7 @@ import urllib.parse
 
 from aiohttp import web
 
-from ..utils.utils import generate_state, save_to_session
+from ..utils.utils import generate_state, save_to_cookies
 from ..config import CONFIG, LOG
 
 
@@ -14,9 +14,6 @@ async def login_request(request: web.Request) -> web.Response:
 
     # Generate a state for callback
     state = await generate_state()
-
-    # Save state to session storage
-    await save_to_session(request, key="oidc_state", value=state)
 
     # Create parameters for authorisation request
     params = {
@@ -32,6 +29,9 @@ async def login_request(request: web.Request) -> web.Response:
 
     # Prepare response
     response = web.HTTPSeeOther(url)
+
+    # Save state to cookies
+    response = await save_to_cookies(response, key="oidc_state", value=state, lifetime=CONFIG.cookie["state_lifetime"], http_only=CONFIG.cookie["http_only"])
 
     # Redirect user to remote AAI server for authentication, this does a 303 redirect
     raise response

--- a/oidc_client/endpoints/token.py
+++ b/oidc_client/endpoints/token.py
@@ -2,7 +2,7 @@
 
 from aiohttp import web
 
-from ..utils.utils import get_from_session
+from ..utils.utils import get_from_cookies
 from ..config import LOG
 
 
@@ -10,7 +10,7 @@ async def token_request(request: web.Request) -> str:
     """Handle token requests."""
     LOG.debug("Handle token request.")
 
-    # Get access token from session storage
-    access_token = await get_from_session(request, "access_token")
+    # Get access token from cookies
+    access_token = await get_from_cookies(request, "access_token")
 
     return access_token

--- a/oidc_client/utils/utils.py
+++ b/oidc_client/utils/utils.py
@@ -5,7 +5,6 @@ import urllib.parse
 
 import aiohttp
 
-from aiohttp_session import get_session
 from aiohttp import web
 from aiocache import cached
 from aiocache.serializers import JsonSerializer
@@ -19,30 +18,6 @@ async def generate_state() -> str:
     """Generate a state for authentication request and return the value for use."""
     LOG.debug("Generate a new state for authentication request.")
     return secrets.token_hex()
-
-
-async def get_from_session(request: web.Request, key: str) -> str:
-    """Get a desired value from session storage."""
-    LOG.debug(f"Retrieve value for {key} from session storage.")
-
-    session = await get_session(request)
-    try:
-        LOG.debug(f"Returning session value for: {key}.")
-        return session[key]
-    except KeyError as e:
-        LOG.error(f"Session has no value for {key}: {e}.")
-        raise web.HTTPUnauthorized(text="401 Uninitialised session.")
-    except Exception as e:
-        LOG.error(f"Failed to retrieve {key} from session: {e}")
-        raise web.HTTPInternalServerError(text=f"500 Session has failed: {e}")
-
-
-async def save_to_session(request: web.Request, key: str = "key", value: str = "value") -> None:
-    """Save a given value to a session key."""
-    LOG.debug(f"Save a value for {key} to session.")
-
-    session = await get_session(request)
-    session[key] = value
 
 
 async def get_from_cookies(request: web.Request, key: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 aiocache==0.11.1
 aiohttp==3.7.4.post0
-aiohttp-session==2.9.0
 async-timeout==3.0.1
 attrs==20.3.0
 Authlib==0.15.3

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,5 +1,7 @@
 import asynctest
 
+from unittest.mock import patch
+
 from aiohttp import web
 
 from oidc_client.endpoints.login import login_request
@@ -25,36 +27,27 @@ class MockResponse:
 class MockRequest:
     """Mocked request class for testing."""
 
-    def __init__(self, query):
+    def __init__(self, cookies, query):
         """Initialise object."""
+        self.cookies = cookies
         self.query = query
-
-    def get(self, key):
-        """For session key."""
-        return key
-
-
-class MockRedirect(Exception):
-    """Mocks HTTPException 303."""
-
-    def __init__(self):
-        """Initialise object."""
 
 
 class TestEndpoints(asynctest.TestCase):
     """Test endpoint processors."""
 
-    @asynctest.mock.patch("aiohttp.web.HTTPSeeOther")
-    @asynctest.mock.patch("oidc_client.endpoints.login.save_to_session")
-    @asynctest.mock.patch("oidc_client.endpoints.login.generate_state")
-    async def test_login_endpoint(self, m_state, m_save, m_response):
+    @patch("aiohttp.web.HTTPSeeOther")
+    @patch("oidc_client.endpoints.login.generate_state")
+    async def test_login_endpoint(self, m_state, m_response):
         """Test login endpoint processor."""
-        m_state.return_value = "5000"
-        m_save.return_value = None
-        m_response.return_value = MockRedirect()
-        with self.assertRaises(MockRedirect):
-            mock_request = MockRequest(query={})
-            await login_request(mock_request)
+        m_state.return_value = 5000
+        assert 5000 == m_state()
+        m_response.return_value = MockResponse()
+        expected_cookies = {"oidc_state": 5000, "domain": "localhost:8080", "httponly": True, "max_age": 3600, "secure": True}
+        m_response_with_cookies = await save_to_cookies(m_response(), key="oidc_state", value=m_state(), lifetime=3600, http_only=True)
+        assert m_response_with_cookies.cookies == expected_cookies
+        with self.assertRaises(web.HTTPSeeOther):
+            await login_request(web.Request)
 
     @asynctest.mock.patch("oidc_client.endpoints.logout.revoke_token")
     @asynctest.mock.patch("oidc_client.endpoints.logout.get_from_cookies")
@@ -66,22 +59,18 @@ class TestEndpoints(asynctest.TestCase):
         with self.assertRaises(web.HTTPSeeOther):
             await logout_request({})
 
-    @asynctest.mock.patch("oidc_client.endpoints.callback.save_to_session")
-    @asynctest.mock.patch("oidc_client.endpoints.callback.get_from_session")
     @asynctest.mock.patch("oidc_client.endpoints.callback.validate_token")
     @asynctest.mock.patch("oidc_client.endpoints.callback.request_token")
-    async def test_callback_endpoint(self, m_token, m_valid, m_session, m_save):
+    async def test_callback_endpoint(self, m_token, m_valid):
         """Test callback endpoint processor."""
         # Test bad request: request doesn't pass state validation
-        m_session.return_value = 5000
-        bad_request = MockRequest(query={"state": 9999, "code": "malicious bunnies"})
+        bad_request = MockRequest(cookies={"oidc_state": 5000}, query={"state": 9999, "code": "malicious bunnies"})
         with self.assertRaises(web.HTTPForbidden):
             await callback_request(bad_request)
         # Test good request: request passes state validation and does a redirect
-        m_session.return_value = 5000
-        good_request = MockRequest(query={"state": 5000, "code": "fluffy bunnies"})
+        good_request = MockRequest(cookies={"oidc_state": 5000}, query={"state": 5000, "code": "fluffy bunnies"})
         m_valid.return_value = True
-        m_save.return_value = None
+        # JWT test
         m_token.return_value = "super.secret.token"
         with self.assertRaises(web.HTTPSeeOther):
             await callback_request(good_request)
@@ -91,11 +80,11 @@ class TestEndpoints(asynctest.TestCase):
         m_response_with_cookies = await save_to_cookies(mock_response, key="access_token", value=await m_token(), lifetime=3600, http_only=True)
         assert m_response_with_cookies.cookies == expected_cookies
 
-    @asynctest.mock.patch("oidc_client.endpoints.token.get_from_session")
-    async def test_token_endpoint(self, m_session):
+    @asynctest.mock.patch("oidc_client.endpoints.token.get_from_cookies")
+    async def test_token_endpoint(self, m_cookies):
         """Test token endpoint processor."""
-        m_session.return_value = "token"
-        mock_request = MockRequest(query={})
+        m_cookies.return_value = "token"
+        mock_request = MockRequest(cookies={"access_token": "token"}, query={})
         token = await token_request(mock_request)
         self.assertEqual(token, "token")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 import re
 
-import aiohttp
 import asynctest
 
 from collections import namedtuple
@@ -14,7 +13,7 @@ from multidict import MultiDict
 
 from oidc_client.utils.utils import generate_state, get_from_cookies, save_to_cookies
 from oidc_client.utils.utils import request_token, query_params, get_jwk, validate_token
-from oidc_client.utils.utils import revoke_token, get_from_session, save_to_session
+from oidc_client.utils.utils import revoke_token
 
 # Mock URLs in functions to replace the real request, checks for http/https/localhost in the beginning
 MOCK_URL = re.compile(r"^(http|localhost)")
@@ -163,29 +162,6 @@ class TestUtils(asynctest.TestCase):
         m.get(MOCK_URL, status=400)
         with self.assertRaises(web.HTTPBadRequest):
             await revoke_token("what")
-
-    @asynctest.mock.patch("oidc_client.utils.utils.get_session", return_value={})
-    async def test_save_to_session(self, m_session):
-        """Test saving to session."""
-        await save_to_session("request", key="hello", value="there")
-
-    @asynctest.mock.patch("oidc_client.utils.utils.get_session", return_value={"hello": "there"})
-    async def test_get_from_session(self, m_session):
-        """Test reading from session."""
-        value = await get_from_session("request", "hello")
-        self.assertEqual(value, "there")
-
-    @asynctest.mock.patch("oidc_client.utils.utils.get_session", return_value={})
-    async def test_get_from_session_not_found(self, m_session):
-        """Test reading from session, key not found."""
-        with self.assertRaises(aiohttp.web_exceptions.HTTPUnauthorized):
-            await get_from_session("request", "missing")
-
-    @asynctest.mock.patch("oidc_client.utils.utils.get_session", return_value=None)
-    async def test_get_from_session_error(self, m_session):
-        """Test reading from session, fatal session error."""
-        with self.assertRaises(aiohttp.web_exceptions.HTTPInternalServerError):
-            await get_from_session("request", "error")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- removed `aiohttp-session`
- reverted back to using cookies only
- added a config switch to allow use of opaque tokens